### PR TITLE
Fix small bug(typo) in reading post-bootstrap.sh

### DIFF
--- a/src/sagemaker_studio_docker_cli/commands.py
+++ b/src/sagemaker_studio_docker_cli/commands.py
@@ -217,7 +217,7 @@ class Commands():
         create_certs = self.read_custom_script(
             f"{home}/sagemaker-studio-docker-cli-extension/src/sagemaker_studio_docker_cli/create_certs.sh"
         )
-        post_bootstrap_script = self.read_custom_script(f"{home}/.sagemaker_studio_docker_cli/pre-bootstrap.sh")
+        post_bootstrap_script = self.read_custom_script(f"{home}/.sagemaker_studio_docker_cli/post-bootstrap.sh")
 
         bootstrap_script = generate_bootstrap_script(
             home,


### PR DESCRIPTION
*Issue #, if available:*
This is small bug (typo) fix.
In commands.py, pre-bootstrap.sh and post-bootstrap.sh are loaded by read_custom_script() function.
in reading post-bootstrap.sh, the file name was defined as pre-bootstrap.sh.

*Description of changes:*
Fix to read post-bootstrap.sh correctly.
